### PR TITLE
Fixed deprecated import of MutableMapping from collections

### DIFF
--- a/dijkstar/graph.py
+++ b/dijkstar/graph.py
@@ -1,4 +1,5 @@
 import collections
+from collections.abc import MutableMapping
 import marshal
 import os
 from copy import copy
@@ -9,7 +10,7 @@ except ImportError:  # pragma: no cover
     import pickle
 
 
-class Graph(collections.MutableMapping):
+class Graph(MutableMapping):
 
     """A very simple graph type.
 


### PR DESCRIPTION
This DeprecationWarning was raised in the tests under Python 3.8:
https://github.com/python/cpython/blob/3.8/Lib/collections/__init__.py#L49