### PR TITLE
Micro op for edge_count() property

### DIFF
--- a/src/dijkstar/graph.py
+++ b/src/dijkstar/graph.py
@@ -125,7 +125,8 @@ class Graph(MutableMapping):
 
     @property
     def edge_count(self):
-        count = sum(len(neighbors) for neighbors in self._data.values())
+        """Total number of neighbors for every node in the graph."""
+        count = sum(map(len, self._data.values()))
         if self._undirected:
             assert count % 2 == 0
             count = count // 2


### PR DESCRIPTION
Possible micro-op for `edge_count()`, though the sum() comprehension would become slightly less descriptive. Do let me know your thoughts on this.

```python
x = {a:str(a) for a in range(100)}

%timeit sum(len(y) for y in x.values())
2.71 μs ± 11.7 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
%timeit sum(map(len, x.values()))
1.27 μs ± 4.85 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```